### PR TITLE
Example PR breaking the consumer-driven contracts

### DIFF
--- a/publishing-service/src/main/avro/Product.avsc
+++ b/publishing-service/src/main/avro/Product.avsc
@@ -17,7 +17,7 @@
       ]
     } },
     { "name": "deliveryPromise", "type": {
-        "type": "enum", "name": "DeliveryPromise", "symbols" : [ "AVAILABLE", "NOT_AVAILABLE", "SOLD_OUT", "PREORDER" ]
+        "type": "enum", "name": "DeliveryPromise", "symbols" : [ "AVAILABLE", "NOT_AVAILABLE", "SOLD_OUT", "PREORDER", "UNKNOWN" ]
       } },
     { "name": "color", "type": [ "null", { "type": "enum", "name": "Color", "type": "enum", "symbols" : [ "BLACK", "WHITE", "RED", "GREEN", "BLUE", "CYAN", "MAGENTA", "YELLOW" ] } ], "default": null },
     { "name": "size", "type": [ "null", "int" ], "default": null }


### PR DESCRIPTION
### This is an example pull request.

<img width="558" alt="101415350-06a55a00-38e8-11eb-82e6-7cde37dffc69" src="https://user-images.githubusercontent.com/3455613/101491563-3134f880-3964-11eb-8fe4-7d7526202612.png">

This PR breaks the consumer-driven contracts by [extending the enum `DeliveryPromise`](https://github.com/talentformation/blueprint-streaming-product-data/pull/5/files#diff-5e425d7251721d13cf3a44b2b367ae8f33c71fa8424409dbb9a7e7b7788c5470L20-R20) by the new option `UNKNOWN`. That is an incompatible change because consumers need to be upgraded first to support the new option.
The code change therefore does not pass the CDC tests in CircleCI.