### PR TITLE
Example PR satisfying the consumer-driven contracts

### DIFF
--- a/publishing-service/src/main/avro/Product.avsc
+++ b/publishing-service/src/main/avro/Product.avsc
@@ -6,7 +6,6 @@
     { "name": "gtin", "type": "string" },
     { "name": "name", "type": "string" },
     { "name": "alternateName", "type": [ "null", "string" ], "default": null },
-    { "name": "brand", "type": "string" },
     { "name": "description", "type": "string" },
     { "name": "price", "type": {
       "type": "record",


### PR DESCRIPTION
### This is an example pull request.

<img width="558" alt="101415350-06a55a00-38e8-11eb-82e6-7cde37dffc69" src="https://user-images.githubusercontent.com/3455613/101491645-490c7c80-3964-11eb-8e20-91c16318597f.png">

This PR [removes the non-optional field `brand`](https://github.com/talentformation/blueprint-streaming-product-data/pull/6/files#diff-5e425d7251721d13cf3a44b2b367ae8f33c71fa8424409dbb9a7e7b7788c5470L9) from the AVRO schema of a `Product`. However, it does not break the consumer-driven contracts because none of the consumers require that field.
The code change therefore passes the CDC tests in CircleCI and could be merged (which we do not to keep this example ^^).